### PR TITLE
Added -Wall and -Werror to CmakeLists.

### DIFF
--- a/ros_package_template/CMakeLists.txt
+++ b/ros_package_template/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(ros_package_template)
 
 ## Use C++11
-add_definitions(-std=c++11)
+add_definitions(-std=c++11 -Wall -Werror)
 
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED

--- a/ros_package_template/CMakeLists.txt
+++ b/ros_package_template/CMakeLists.txt
@@ -2,7 +2,10 @@ cmake_minimum_required(VERSION 2.8.3)
 project(ros_package_template)
 
 ## Use C++11
-add_definitions(-std=c++11 -Wall -Werror)
+add_definitions(-std=c++11)
+## By adding -Wall and -Werror, the compiler does not ignore warnings anymore,
+## enforcing cleaner code.
+#add_definitions(-std=c++11 -Wall -Werror)
 
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED


### PR DESCRIPTION
This shows all build warnings and turns them into errors, meaning that you cannot build a package with warnings anymore. I introduced this for the ANYdrive SDK and could fix all warnings so far.

In my opinion this should be standard for all our packages.

Additional literature:
https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html