### PR TITLE
adapted overview section structure to be compatible with build server software overview generation

### DIFF
--- a/ros_package_template/README.md
+++ b/ros_package_template/README.md
@@ -4,7 +4,9 @@
 
 This is a template: replace, remove, and add where required. Describe here what this package does and what it's meant for in a few sentences.
 
-The PACKAGE NAME package has been tested under [ROS] Indigo and Ubuntu 14.04. This is research code, expect that it changes often and any fitness for a particular purpose is disclaimed.
+**Keywords:** example, package, template
+
+### License
 
 The source code is released under a [BSD 3-Clause license](ros_package_template/LICENSE).
 
@@ -12,7 +14,10 @@ The source code is released under a [BSD 3-Clause license](ros_package_template/
 Maintainer: Péter Fankhauser, pfankhauser@ethz.ch  
 Affiliation: Autonomous Systems Lab, ETH Zurich**
 
+The PACKAGE NAME package has been tested under [ROS] Indigo and Ubuntu 14.04. This is research code, expect that it changes often and any fitness for a particular purpose is disclaimed.
+
 [![Build Status](http://rsl-ci.ethz.ch/buildStatus/icon?job=ros_best_practices)](http://rsl-ci.ethz.ch/job/ros_best_practices/)
+
 
 ![Example image](doc/example.jpg)
 


### PR DESCRIPTION
Moving License / authors to subsection such that it does not get included in software overview list